### PR TITLE
Add: multi-modal training for TD-MPC2

### DIFF
--- a/humanoid_bench/wrappers.py
+++ b/humanoid_bench/wrappers.py
@@ -457,6 +457,7 @@ class ObservationWrapper(BaseWrapper):
         super().__init__(task)
 
         sensors = kwargs.get("sensors").split(",")
+        self._proprio_ob = "proprio" in sensors
         self._tactile_ob = "tactile" in sensors
         self._camera_ob = "image" in sensors
         self._privileged_ob = "privileged" in sensors
@@ -468,24 +469,16 @@ class ObservationWrapper(BaseWrapper):
 
     @property
     def observation_space(self):
-        proprio_space = Box(
-            low=-np.inf,
-            high=np.inf,
-            shape=(self.task._env.robot.dof * 2 - 1 - 13,),
-            dtype=np.float64,
-        )
+        spaces = []
 
-        if self._camera_ob:
-            image_example = self.get_camera_obs()
-            camera_spaces = [
-                (
-                    key,
-                    Box(
-                        low=0, high=255, shape=image_example[key].shape, dtype=np.uint8
-                    ),
-                )
-                for key in image_example
-            ]
+        if self._proprio_ob:
+            proprio_space = Box(
+                low=-np.inf,
+                high=np.inf,
+                shape=(self.task._env.robot.dof * 2 - 1 - 13,),
+                dtype=np.float64,
+            )
+            spaces.append(("proprio", proprio_space))
 
         if self._tactile_ob:
             tactile_example = self.get_tactile_obs()
@@ -501,38 +494,38 @@ class ObservationWrapper(BaseWrapper):
                 )
                 for key in tactile_example
             ]
+            spaces.extend(tactile_spaces)
+
+        if self._camera_ob:
+            image_example = self.get_camera_obs()
+            camera_spaces = [
+                (
+                    key,
+                    Box(
+                        low=0, high=255, shape=image_example[key].shape, dtype=np.uint8
+                    ),
+                )
+                for key in image_example
+            ]
+            spaces.extend(camera_spaces)
+
         if self._privileged_ob:
             privileged_space = self._env.observation_space
-
-        if not self._privileged_ob and not self._tactile_ob and not self._camera_ob:
-            return proprio_space
-
-        spaces = [("proprio", proprio_space)]
-        if self._privileged_ob:
             spaces.append(("privileged", privileged_space))
-        if self._tactile_ob:
-            spaces.extend(tactile_spaces)
-        if self._camera_ob:
-            spaces.extend(camera_spaces)
-            
+
         return Dict(spaces)
 
     def get_obs(self):
-        position = self.task._env.robot.joint_angles()
-        velocity = self.task._env.robot.joint_velocities()
-        state = np.concatenate((position, velocity))
+        obses = []
 
-        if not self._privileged_ob and not self._tactile_ob and not self._camera_ob:
-            return state
+        if self._proprio_ob:
+            proprio = self.get_proprio_obs()
+            obses.extend(list(proprio.items()))
 
-        obses = [("proprio", state)]
-
-        tactile = None
         if self._tactile_ob:
             tactile = self.get_tactile_obs()
             obses.extend(list(tactile.items()))
 
-        camera = None
         if self._camera_ob:
             camera = self.get_camera_obs()
             obses.extend(list(camera.items()))
@@ -542,6 +535,12 @@ class ObservationWrapper(BaseWrapper):
             obses.append(("privileged", privileged))
 
         return dict(obses)
+
+    def get_proprio_obs(self):
+        position = self.task._env.robot.joint_angles()
+        velocity = self.task._env.robot.joint_velocities()
+        state = np.concatenate((position, velocity))
+        return {"proprio": state}
 
     def get_tactile_obs(self):
         """

--- a/tdmpc2/common/layers.py
+++ b/tdmpc2/common/layers.py
@@ -1,3 +1,4 @@
+import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -135,6 +136,27 @@ def mlp(in_dim, mlp_dims, out_dim, act=None, dropout=0.0):
     return nn.Sequential(*mlp)
 
 
+def mlp_tac(in_dims, mlp_dims, out_dim, act=None, dropout=0.0):
+    """
+    Basic building block of TD-MPC2.
+    MLP with LayerNorm, Mish activations, and optionally dropout.
+    """
+    if isinstance(mlp_dims, int):
+        mlp_dims = [mlp_dims]
+    dims = [math.prod(in_dims)] + mlp_dims + [out_dim]
+    mlp = nn.ModuleList([
+        torch.nn.Flatten(start_dim=-3, end_dim=-1),
+    ])
+    for i in range(len(dims) - 2):
+        mlp.append(NormedLinear(dims[i], dims[i + 1], dropout=dropout * (i == 0)))
+    mlp.append(
+        NormedLinear(dims[-2], dims[-1], act=act)
+        if act
+        else nn.Linear(dims[-2], dims[-1])
+    )
+    return nn.Sequential(*mlp)
+
+
 def conv(in_shape, num_channels, act=None):
     """
     Basic convolutional encoder for TD-MPC2 with raw image observations.
@@ -162,6 +184,7 @@ def enc(cfg, out={}):
     """
     Returns a dictionary of encoders for each observation in the dict.
     """
+    hidden_dim = 0
     for k in cfg.obs_shape.keys():
         if k == "state":
             out[k] = mlp(
@@ -170,10 +193,34 @@ def enc(cfg, out={}):
                 cfg.latent_dim,
                 act=SimNorm(cfg),
             )
+            out_dim = cfg.enc_dim
         elif k == "rgb":
             out[k] = conv(cfg.obs_shape[k], cfg.num_channels, act=SimNorm(cfg))
+            out_dim = cfg.num_channels * 4 * 4
+        elif k == "proprio":
+            out[k] = mlp(
+                cfg.obs_shape[k][0] + cfg.task_dim,
+                max(cfg.num_enc_layers - 1, 1) * [cfg.enc_dim],
+                cfg.enc_dim,
+                act=SimNorm(cfg),
+            )
+            out_dim = cfg.enc_dim
+        elif k.endswith("_eye"):
+            out[k] = conv(cfg.obs_shape[k], cfg.num_channels, act=SimNorm(cfg))
+            out_dim = cfg.num_channels * 4 * 4
+        elif k.startswith("tactile_"):
+            out[k] = mlp_tac(
+                cfg.obs_shape[k],
+                max(cfg.num_enc_layers - 1, 1) * [cfg.enc_dim],
+                cfg.enc_dim,
+                act=SimNorm(cfg),
+            )
+            out_dim = cfg.enc_dim
         else:
             raise NotImplementedError(
                 f"Encoder for observation type {k} not implemented."
             )
-    return nn.ModuleDict(out)
+        hidden_dim += out_dim
+    return nn.Sequential(
+        nn.ModuleDict(out), nn.Linear(hidden_dim, cfg.latent_dim)
+    )

--- a/tdmpc2/common/world_model.py
+++ b/tdmpc2/common/world_model.py
@@ -118,9 +118,18 @@ class WorldModel(nn.Module):
         """
         if self.cfg.multitask:
             obs = self.task_emb(obs, task)
+        encoder, projector = self._encoder
         if self.cfg.obs == "rgb" and obs.ndim == 5:
-            return torch.stack([self._encoder[self.cfg.obs](o) for o in obs])
-        return self._encoder[self.cfg.obs](obs)
+            return torch.stack([encoder[self.cfg.obs](o) for o in obs])
+        elif self.cfg.obs == "multi-modal":
+            z = torch.cat([
+                torch.stack([encoder[k](o) for o in v])
+                if v.ndim == 5
+                else encoder[k](v)
+                for k, v in obs.items()
+            ], dim=-1)
+            return projector(z)
+        return encoder[self.cfg.obs](obs)
 
     def next(self, z, a, task):
         """

--- a/tdmpc2/config.yaml
+++ b/tdmpc2/config.yaml
@@ -3,7 +3,7 @@ defaults:
 
 # environment
 task: humanoid_h1dualarm-rub-v0
-obs: state
+obs: multi-modal
 
 exp_group: ???
 exp_name: tdmpc2
@@ -106,6 +106,7 @@ mean_path: ???
 var_path: ???
 policy_type: ???
 small_obs: ???
+sensors: proprio
 tactile_info: ???
 
 instruct: false

--- a/tdmpc2/envs/__init__.py
+++ b/tdmpc2/envs/__init__.py
@@ -6,6 +6,7 @@ from omegaconf import MissingMandatoryValue
 
 from tdmpc2.envs.wrappers.multitask import MultitaskWrapper
 from tdmpc2.envs.wrappers.pixels import PixelWrapper
+from tdmpc2.envs.wrappers.multi_modal import MultimodalWrapper
 from tdmpc2.envs.wrappers.tensor import TensorWrapper
 
 
@@ -83,7 +84,8 @@ def make_env(cfg):
         env = TensorWrapper(env)
     if cfg.get("obs", "state") == "rgb":
         env = PixelWrapper(cfg, env)
-
+    if cfg.get("obs", "state") == "multi-modal":
+        env = MultimodalWrapper(cfg, env)
 
     try:  # Dict
         cfg.obs_shape = {k: v.shape for k, v in env.observation_space.spaces.items()}

--- a/tdmpc2/envs/humanoid.py
+++ b/tdmpc2/envs/humanoid.py
@@ -22,10 +22,22 @@ class HumanoidWrapper(gym.Wrapper):
         self.env = env
         self.cfg = cfg
 
+    @staticmethod
+    def _process_obs(obs):
+        if isinstance(obs, dict):
+            for key, value in obs.items():
+                obs[key] = value.astype(np.float32)
+        else:
+            obs = obs.astype(np.float32)
+        return obs
+
+    def reset(self, options=None):
+        obs, info = self.env.reset(options=options)
+        return self._process_obs(obs), info
+
     def step(self, action):
         obs, reward, done, truncated, info = self.env.step(action.copy())
-        obs = obs.astype(np.float32)
-        return obs, reward, done, truncated, info
+        return self._process_obs(obs), reward, done, truncated, info
 
     @property
     def unwrapped(self):
@@ -63,6 +75,8 @@ def make_env(cfg):
         var_path=var_path,
         policy_type=policy_type,
         small_obs=small_obs,
+        obs_wrapper='true' if cfg.obs == "multi-modal" else None,
+        sensors=cfg.sensors if cfg.obs == "multi-modal" else None,
         tactile_info=tactile_info,
     )
     env = HumanoidWrapper(env, cfg)

--- a/tdmpc2/envs/wrappers/multi_modal.py
+++ b/tdmpc2/envs/wrappers/multi_modal.py
@@ -1,0 +1,54 @@
+from collections import deque
+
+import gymnasium as gym
+import numpy as np
+import torch
+
+
+class MultimodalWrapper(gym.Wrapper):
+    """
+    Wrapper for pixel observations. Compatible with DMControl environments.
+    """
+
+    def __init__(self, cfg, env, num_frames=3, render_size=64):
+        super().__init__(env)
+        self.cfg = cfg
+        self.env = env
+        self._frames = deque([], maxlen=num_frames)
+        self._render_size = render_size
+
+    @property
+    def observation_space(self):
+        obs_space = self.env.observation_space
+        if type(obs_space) == gym.spaces.Dict:
+            for k in obs_space.keys():
+                if k.endswith("_eye"):
+                    obs_space[k] = gym.spaces.Box(
+                        low=0,
+                        high=255,
+                        shape=(3, self._render_size, self._render_size),
+                        dtype=np.uint8,
+                    )
+        return obs_space
+
+    def _process_obs(self, obs):
+        if type(obs) == dict:
+            for k in obs.keys():
+                if k.endswith("_eye"):
+                    image = obs[k].permute(2, 0, 1).unsqueeze(0)  # -> (1, 3, 256, 256)
+                    image_resized = torch.nn.functional.interpolate(
+                        image,
+                        size=(self._render_size, self._render_size),
+                        mode='bilinear',
+                         align_corners=False
+                    )
+                    obs[k] = image_resized.squeeze(0)  # -> (3, 64, 64)
+        return obs
+
+    def reset(self, options=None):
+        obs, info = self.env.reset(options=options)
+        return self._process_obs(obs), info
+
+    def step(self, action):
+        obs, reward, done, truncated, info = self.env.step(action)
+        return self._process_obs(obs), reward, done, truncated, info

--- a/tdmpc2/tdmpc2.py
+++ b/tdmpc2/tdmpc2.py
@@ -105,7 +105,11 @@ class TDMPC2:
         Returns:
                 torch.Tensor: Action to take in the environment.
         """
-        obs = obs.to(self.device, non_blocking=True).unsqueeze(0)
+        if isinstance(obs, dict):
+            for key in obs:
+                obs[key] = obs[key].to(self.device, non_blocking=True).unsqueeze(0)
+        else:
+            obs = obs.to(self.device, non_blocking=True).unsqueeze(0)
         if task is not None:
             task = torch.tensor([task], device=self.device)
         z = self.model.encode(obs, task)

--- a/tdmpc2/trainer/online_trainer.py
+++ b/tdmpc2/trainer/online_trainer.py
@@ -56,8 +56,7 @@ class OnlineTrainer(Trainer):
         """Creates a TensorDict for a new episode."""
         if isinstance(obs, dict):
             obs = TensorDict(obs, batch_size=(), device="cpu")
-        else:
-            obs = obs.unsqueeze(0).cpu()
+        obs = obs.unsqueeze(0).cpu()
         if action is None:
             action = torch.full_like(self.env.rand_act(), float("nan"))
         if reward is None:


### PR DESCRIPTION
### Summary
As a default, the environment returns a privileged state of the environment (e.g., robot state + environment state). To get proprio, visual, and tactile sensing, set `obs=multi-modal` and accordingly select the required sensors, e.g. `sensors="proprio,image,tactile"`.

Full test instruction:
```bash
python -m tdmpc2.train task=humanoid_h1touch-window-v0 --obs='multi-modal' --sensors='proprio,image,tactile'
```

### Encoder Architecture
- **proprio**: MLP
- **image**: CNN
- **tactile**: flatten+MLP
- Embeddings from all modalities are passed through a Linear layer to project them into a shared hidden dimension.

The number of learnable parameters:
- `sensors='propro'`: 5,308,632
- `sensors='image'`: 5,697,176
- `sensors='tactile'`: 15,920,856
- `sensors='propro,image'`: 16,154,328
- `sensors='propro,tactile'`: 16,542,872
- `sensors='image,tactile'`: 5,930,648
- `sensors='propro,image,tactile'`: 16,776,344